### PR TITLE
Manual control of display refresh

### DIFF
--- a/code.py
+++ b/code.py
@@ -94,7 +94,7 @@ MAZE_ROWS = 31
 # Movement speeds (pixels per frame at game resolution)
 PACMAN_SPEED = 1.3  # was 1.3
 GHOST_SPEED = 1.22  # was 1.22
-FRAME_DELAY = 0.016  # ~60 FPS target  was 0.016
+FPS = 60
 
 # Directions
 DIR_NONE = 0
@@ -496,6 +496,8 @@ except Exception as e:
     print(f"Display init error: {e}")
 
     sys.exit()
+finally:
+    display.auto_refresh = False
 
 main_group = displayio.Group()
 display.root_group = main_group
@@ -1485,6 +1487,7 @@ print(f"Free memory: {gc.mem_free()}")
 print("Controller:", "Connected" if controller_connected else "Not found")
 
 # Play startup
+display.refresh()
 sound.play_startup()
 game_state = STATE_READY
 ready_timer = 0
@@ -1499,8 +1502,11 @@ if ready_label:
 while supervisor.runtime.serial_bytes_available:
     sys.stdin.read(1)
 
+# frames = 0
+# frame_timer = time.monotonic()
+
 while True:
-    start_time = time.monotonic()
+    #start_time = time.monotonic()
 
     controller_input = False
     if controller_connected:
@@ -1653,6 +1659,7 @@ while True:
                     death_frame_idx = 0
                     for g in ghosts:
                         g.sprite.hidden = True
+                    display.refresh()
                     time.sleep(1.0)
                     break
 
@@ -1820,6 +1827,10 @@ while True:
     # prev_time = now
 
     # Frame timing
-    elapsed = time.monotonic() - start_time
-    if elapsed < FRAME_DELAY:
-        time.sleep(FRAME_DELAY - elapsed)
+    display.refresh(target_frames_per_second=FPS)
+
+    # frames += 1
+    # if (frame_timer_now := time.monotonic()) - frame_timer > 1.0:
+    #     print(f"fps = {frames / (frame_timer_now - frame_timer)}")
+    #     frames = 0
+    #     frame_timer = frame_timer_now


### PR DESCRIPTION
This is a bit of an experiment to compare against the current timing methodology (using `time.sleep`) versus `display.refresh(target_frames_per_second=60)`. I'm uncertain as to which is the best route to take and I don't notice a significant difference except that `display.refresh` tends to go beyond 60 fps when idling.

| | time.sleep | display.refresh |
|-|-|-|
| Average | 36.89 | 40.67 |
| Max | 62.51 | 79.38 |
| Min | 9.25 | 8.98 |
| Standard Deviation | 12.52 | 15.41 |