### PR TITLE
Support user resolutions

### DIFF
--- a/code.py
+++ b/code.py
@@ -59,14 +59,14 @@ if not SCREEN_WIDE and SCORE_SCALE > 1:
 DISPLAY_ROTATION = os.getenv("CIRCUITPY_DISPLAY_ROTATION", 0)
 DISPLAY_VERTICAL = DISPLAY_ROTATION in (90, 270)  # Tate mode / vertical orientation
 
-if SCREEN_WIDE:
-    if GAME_SCALE > 1:  # higher resolution 16:9 displays
-        GAME_SCALE = 1
-        if DISPLAY_VERTICAL:
-            SCORE_SCALE = 1
-    elif not DISPLAY_VERTICAL:  # force rotation on lower resolution 16:9 displays
-        DISPLAY_ROTATION = 270
-        DISPLAY_VERTICAL = True
+if SCREEN_WIDE and GAME_SCALE > 1:  # higher resolution 16:9 displays
+    GAME_SCALE = 1
+    if DISPLAY_VERTICAL:
+        SCORE_SCALE = 1
+elif SCREEN_WIDE and not DISPLAY_VERTICAL:  # force 4:3 aspect ratio if lower resolution horizontal 16:9 display
+    SCREEN_WIDTH = 320
+    SCREEN_HEIGHT = 240
+    SCREEN_WIDE = False
 
 DISPLAY_WIDTH = SCREEN_HEIGHT if DISPLAY_VERTICAL else SCREEN_WIDTH
 DISPLAY_HEIGHT = SCREEN_WIDTH if DISPLAY_VERTICAL else SCREEN_HEIGHT


### PR DESCRIPTION
- This update enables support for all resolution modes support by the Fruit Jam (see `adafruit_fruitjam.peripherals.VALID_DISPLAY_SIZES`) as configured by `CIRCUITPY_DISPLAY_WIDTH` environment variable (see [docs](https://docs.circuitpython.org/en/latest/docs/environment.html#circuitpy-display-width-sunton-matouch)).
- If the screen is detected as "widescreen", it centers the game area rather than slightly offset because there is enough room for left panel ui elements.
- Supports vertical orientation ("tate mode") as configured by `CIRCUITPY_DISPLAY_ROTATION` (see [docs](https://docs.circuitpython.org/en/latest/docs/environment.html#circuitpy-display-rotation)). This allows the entire gameplay area to be visible rather than slightly cut off on the top and bottom (and its even more so on widescreen displays).
- UI elements are scaled when using higher resolution in horizontal orientation (looks off to me otherwise)
- "Game over" and "Ready" text is better positioned in game area according to original
- Fixed game area offset (was adjusting for scale when it didn't need to be)